### PR TITLE
値段の追加

### DIFF
--- a/src/components/atoms/ProductPrice/index.stories.tsx
+++ b/src/components/atoms/ProductPrice/index.stories.tsx
@@ -9,10 +9,18 @@ const meta: Meta<typeof ProductPrice> = {
 export default meta;
 
 type Story = StoryObj<typeof ProductPrice>;
-export const Default: Story = {
+export const Discounted: Story = {
   args: {
     discounted: true,
     originalPrice: 1000,
+    sellingPrice: 500,
+  },
+};
+
+export const Normal: Story = {
+  args: {
+    discounted: false,
+    originalPrice: 500,
     sellingPrice: 500,
   },
 };

--- a/src/components/atoms/ProductPrice/index.stories.tsx
+++ b/src/components/atoms/ProductPrice/index.stories.tsx
@@ -1,0 +1,18 @@
+import { StoryObj, Meta } from '@storybook/react';
+import { ProductPrice } from '.';
+
+const meta: Meta<typeof ProductPrice> = {
+  title: 'atoms/ProductPrice',
+  component: ProductPrice,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProductPrice>;
+export const Default: Story = {
+  args: {
+    discounted: true,
+    originalPrice: 1000,
+    sellingPrice: 500,
+  },
+};

--- a/src/components/atoms/ProductPrice/index.tsx
+++ b/src/components/atoms/ProductPrice/index.tsx
@@ -7,10 +7,6 @@ const Container = styled.section`
   align-items: flex-end;
 `;
 
-const PriceWrapper = styled.div`
-  display: flex;
-`;
-
 const TaxExcluded = styled.div`
   font-size: ${fontSizes.fontSize24};
   font-style: ${fonts.NotoSansJP};
@@ -26,6 +22,7 @@ const DiscountedSellingPrice = styled.div`
   color: ${colors.Red};
   font-size: ${fontSizes.fontSize36};
   font-style: ${fonts.Roboto};
+  line-height: 1.2;
 `;
 
 const DiscountedYen = styled.div`
@@ -38,6 +35,7 @@ const NormalSellingPrice = styled.div`
   color: ${colors.Black};
   font-size: ${fontSizes.fontSize36};
   font-style: ${fonts.Roboto};
+  line-height: 1.2;
 `;
 
 const NormalYen = styled.div`
@@ -60,16 +58,16 @@ export const ProductPrice: FC<ProductPriceProps> = ({
   <Container>
     <TaxExcluded>税抜</TaxExcluded>
     {discounted ? (
-      <PriceWrapper>
+      <>
         <DiscountedOriginalPrice>{originalPrice}→</DiscountedOriginalPrice>
         <DiscountedSellingPrice>{sellingPrice}</DiscountedSellingPrice>
         <DiscountedYen>円</DiscountedYen>
-      </PriceWrapper>
+      </>
     ) : (
-      <PriceWrapper>
+      <>
         <NormalSellingPrice>{sellingPrice}</NormalSellingPrice>
         <NormalYen>円</NormalYen>
-      </PriceWrapper>
+      </>
     )}
   </Container>
 );

--- a/src/components/atoms/ProductPrice/index.tsx
+++ b/src/components/atoms/ProductPrice/index.tsx
@@ -1,22 +1,32 @@
 import { FC } from 'react';
 import { colors, fontSizes, fonts } from 'src/styles/Tokens';
+import { tb } from 'src/styles/media';
 import styled from 'styled-components';
 
 const Container = styled.section`
   display: flex;
   align-items: flex-end;
   column-gap: 8px;
+  ${tb`
+    column-gap: 4px;
+  `}
 `;
 
 const TaxExcluded = styled.div`
   font-size: ${fontSizes.fontSize24};
   font-style: ${fonts.NotoSansJP};
+  ${tb`
+    font-size: ${fontSizes.fontSize14};
+  `}
 `;
 
 const DiscountedOriginalPrice = styled.div`
   color: #aaa;
   font-size: ${fontSizes.fontSize24};
   font-style: ${fonts.Roboto};
+  ${tb`
+    font-size: ${fontSizes.fontSize14};
+  `}
 `;
 
 const DiscountedSellingPrice = styled.div`
@@ -24,12 +34,18 @@ const DiscountedSellingPrice = styled.div`
   font-size: ${fontSizes.fontSize36};
   font-style: ${fonts.Roboto};
   line-height: 1.2;
+  ${tb`
+    font-size: ${fontSizes.fontSize24};
+  `}
 `;
 
 const DiscountedYen = styled.div`
   color: ${colors.Red};
   font-size: ${fontSizes.fontSize24};
   font-style: ${fonts.NotoSansJP};
+  ${tb`
+    font-size: ${fontSizes.fontSize14};
+  `}
 `;
 
 const NormalSellingPrice = styled.div`
@@ -37,12 +53,18 @@ const NormalSellingPrice = styled.div`
   font-size: ${fontSizes.fontSize36};
   font-style: ${fonts.Roboto};
   line-height: 1.2;
+  ${tb`
+    font-size: ${fontSizes.fontSize24};
+  `}
 `;
 
 const NormalYen = styled.div`
   color: ${colors.Black};
   font-size: ${fontSizes.fontSize24};
   font-style: ${fonts.NotoSansJP};
+  ${tb`
+    font-size: ${fontSizes.fontSize14};
+  `}
 `;
 
 type ProductPriceProps = {

--- a/src/components/atoms/ProductPrice/index.tsx
+++ b/src/components/atoms/ProductPrice/index.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 const Container = styled.section`
   display: flex;
   align-items: flex-end;
+  column-gap: 8px;
 `;
 
 const TaxExcluded = styled.div`

--- a/src/components/atoms/ProductPrice/index.tsx
+++ b/src/components/atoms/ProductPrice/index.tsx
@@ -1,0 +1,75 @@
+import { FC } from 'react';
+import { colors, fontSizes, fonts } from 'src/styles/Tokens';
+import styled from 'styled-components';
+
+const Container = styled.section`
+  display: flex;
+  align-items: flex-end;
+`;
+
+const PriceWrapper = styled.div`
+  display: flex;
+`;
+
+const TaxExcluded = styled.div`
+  font-size: ${fontSizes.fontSize24};
+  font-style: ${fonts.NotoSansJP};
+`;
+
+const DiscountedOriginalPrice = styled.div`
+  color: #aaa;
+  font-size: ${fontSizes.fontSize24};
+  font-style: ${fonts.Roboto};
+`;
+
+const DiscountedSellingPrice = styled.div`
+  color: ${colors.Red};
+  font-size: ${fontSizes.fontSize36};
+  font-style: ${fonts.Roboto};
+`;
+
+const DiscountedYen = styled.div`
+  color: ${colors.Red};
+  font-size: ${fontSizes.fontSize24};
+  font-style: ${fonts.NotoSansJP};
+`;
+
+const NormalSellingPrice = styled.div`
+  color: ${colors.Black};
+  font-size: ${fontSizes.fontSize36};
+  font-style: ${fonts.Roboto};
+`;
+
+const NormalYen = styled.div`
+  color: ${colors.Black};
+  font-size: ${fontSizes.fontSize24};
+  font-style: ${fonts.NotoSansJP};
+`;
+
+type ProductPriceProps = {
+  discounted: boolean;
+  originalPrice: number;
+  sellingPrice: number;
+};
+
+export const ProductPrice: FC<ProductPriceProps> = ({
+  discounted,
+  originalPrice,
+  sellingPrice,
+}) => (
+  <Container>
+    <TaxExcluded>税抜</TaxExcluded>
+    {discounted ? (
+      <PriceWrapper>
+        <DiscountedOriginalPrice>{originalPrice}→</DiscountedOriginalPrice>
+        <DiscountedSellingPrice>{sellingPrice}</DiscountedSellingPrice>
+        <DiscountedYen>円</DiscountedYen>
+      </PriceWrapper>
+    ) : (
+      <PriceWrapper>
+        <NormalSellingPrice>{sellingPrice}</NormalSellingPrice>
+        <NormalYen>円</NormalYen>
+      </PriceWrapper>
+    )}
+  </Container>
+);

--- a/src/styles/Tokens.ts
+++ b/src/styles/Tokens.ts
@@ -33,6 +33,7 @@ export const fontSizes = {
   fontSize28: '28px',
   fontSize30: '30px',
   fontSize32: '32px',
+  fontSize36: '36px',
 } as const;
 
 export const fonts = {


### PR DESCRIPTION
# 概要
詳細画面に表示する値段部分の実装を行いました。
組み込みは後ほどする予定です。

# スクリーンショット
|storybook|figma|
|-|-|
|<img width="111" alt="image" src="https://github.com/arfes0e2b3c/yumeshop-frontend/assets/86275398/7fb3715c-5b12-42ea-af54-659f850d505d">|<img width="201" alt="image" src="https://github.com/arfes0e2b3c/yumeshop-frontend/assets/86275398/4ce4e9e5-6d14-4cb3-b1f9-41670d12f7a8">|
|<img width="176" alt="image" src="https://github.com/arfes0e2b3c/yumeshop-frontend/assets/86275398/758171eb-fa53-4d52-8552-5637bbfc5f66">|<img width="240" alt="image" src="https://github.com/arfes0e2b3c/yumeshop-frontend/assets/86275398/d7823eb3-0718-4e12-a9ba-b07109c594ad">|

# 動作確認
- storybookを起動(yarn run storybook)
- [atomsのProductPrice](http://localhost:6006/?path=/docs/atoms-productprice--docs)にアクセス
- デザインの齟齬が無いか確認