### PR TITLE
タグの追加

### DIFF
--- a/src/components/atoms/ProductTag/index.stories.tsx
+++ b/src/components/atoms/ProductTag/index.stories.tsx
@@ -16,3 +16,11 @@ export const Default: Story = {
     color: 'green',
   },
 };
+
+export const LongText: Story = {
+  args: {
+    path: '/tags/f43b4797-f9aa-01dc-6877-115b2a838ef9',
+    name: '新商品新商品新商品新商品新商品新商品新商品新商品新商品新商品',
+    color: 'green',
+  },
+};

--- a/src/components/atoms/ProductTag/index.stories.tsx
+++ b/src/components/atoms/ProductTag/index.stories.tsx
@@ -1,0 +1,18 @@
+import { StoryObj, Meta } from '@storybook/react';
+import { ProductTag } from '.';
+
+const meta: Meta<typeof ProductTag> = {
+  title: 'atoms/ProductTag',
+  component: ProductTag,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProductTag>;
+export const Default: Story = {
+  args: {
+    path: '/tags/f43b4797-f9aa-01dc-6877-115b2a838ef9',
+    name: '新商品',
+    color: 'green',
+  },
+};

--- a/src/components/atoms/ProductTag/index.tsx
+++ b/src/components/atoms/ProductTag/index.tsx
@@ -6,6 +6,9 @@ import styled from 'styled-components';
 
 const Container = styled.section<{ color: string }>`
   width: fit-content;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
   background-color: ${(props) => props.color};
   color: ${colors.White};
 `;

--- a/src/components/atoms/ProductTag/index.tsx
+++ b/src/components/atoms/ProductTag/index.tsx
@@ -3,9 +3,9 @@ import { FC } from 'react';
 import { colors, fontSizes } from 'src/styles/Tokens';
 import styled from 'styled-components';
 
-const Container = styled.section`
+const Container = styled.section<{ color: string }>`
   width: fit-content;
-  background-color: ${colors.Black};
+  background-color: ${(props) => props.color};
   color: ${colors.White};
 `;
 
@@ -23,7 +23,7 @@ type ProductTagProps = {
 
 export const ProductTag: FC<ProductTagProps> = ({ path, name, color }) => (
   <Link href={path}>
-    <Container>
+    <Container color={color}>
       <TagText>{name}</TagText>
     </Container>
   </Link>

--- a/src/components/atoms/ProductTag/index.tsx
+++ b/src/components/atoms/ProductTag/index.tsx
@@ -4,7 +4,13 @@ import { colors, fontSizes, fonts } from 'src/styles/Tokens';
 import { tb } from 'src/styles/media';
 import styled from 'styled-components';
 
-const Container = styled.section<{ color: string }>`
+type ProductTagProps = {
+  path: string;
+  name: string;
+  color: string;
+};
+
+const Container = styled.section<Pick<ProductTagProps, 'color'>>`
   width: fit-content;
   max-width: 100%;
   overflow: hidden;
@@ -22,12 +28,6 @@ const TagText = styled.p`
     font-size: ${fontSizes.fontSize12};
   `}
 `;
-
-type ProductTagProps = {
-  path: string;
-  name: string;
-  color: string;
-};
 
 export const ProductTag: FC<ProductTagProps> = ({ path, name, color }) => (
   <Link href={path}>

--- a/src/components/atoms/ProductTag/index.tsx
+++ b/src/components/atoms/ProductTag/index.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import { FC } from 'react';
+import { colors, fontSizes } from 'src/styles/Tokens';
+import styled from 'styled-components';
+
+const Container = styled.section`
+  width: fit-content;
+  background-color: ${colors.Black};
+  color: ${colors.White};
+`;
+
+const TagText = styled.p`
+  padding: 0 8px;
+  font-size: ${fontSizes.fontSize22};
+  line-height: 32px;
+`;
+
+type ProductTagProps = {
+  path: string;
+  name: string;
+  color: string;
+};
+
+export const ProductTag: FC<ProductTagProps> = ({ path, name, color }) => (
+  <Link href={path}>
+    <Container>
+      <TagText>{name}</TagText>
+    </Container>
+  </Link>
+);

--- a/src/components/atoms/ProductTag/index.tsx
+++ b/src/components/atoms/ProductTag/index.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { FC } from 'react';
-import { colors, fontSizes } from 'src/styles/Tokens';
+import { colors, fontSizes, fonts } from 'src/styles/Tokens';
+import { tb } from 'src/styles/media';
 import styled from 'styled-components';
 
 const Container = styled.section<{ color: string }>`
@@ -12,7 +13,11 @@ const Container = styled.section<{ color: string }>`
 const TagText = styled.p`
   padding: 0 8px;
   font-size: ${fontSizes.fontSize22};
-  line-height: 32px;
+  font-family: ${fonts.NotoSansJP};
+  ${tb`
+    padding: 0 4px;
+    font-size: ${fontSizes.fontSize12};
+  `}
 `;
 
 type ProductTagProps = {


### PR DESCRIPTION
# 概要
詳細画面に表示するタグの実装を行いました。
組み込みは後ほどする予定です。
タグ内での改行を禁止しています。
存在しない色を渡された際の処理ができていません。

# スクリーンショット
|storybook|figma|
|-|-|
|![image](https://github.com/arfes0e2b3c/yumeshop-frontend/assets/86275398/5839ec54-6cdb-4127-95c9-162d76766840)|![image](https://github.com/arfes0e2b3c/yumeshop-frontend/assets/86275398/713a0127-1dd1-44b4-b108-d74c82531e00)|

# 動作確認
- storybookを起動(yarn run storybook)
- [atomsのProductTag](http://localhost:6006/?path=/story/atoms-producttag--default)にアクセス
- デザインの齟齬が無いか確認