### PR TITLE
関連商品部分の実装

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,12 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'picsum.photos',
+      },
+    ],
+  },
   reactStrictMode: true,
 }

--- a/src/components/atoms/ProductCard/index.tsx
+++ b/src/components/atoms/ProductCard/index.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { FC } from 'react';
+import { colors } from 'src/styles/Tokens';
 import { tb } from 'src/styles/media';
 import styled from 'styled-components';
 
@@ -24,9 +25,10 @@ const ProductImage = styled(Image)`
 
 const ProductTitle = styled.div`
   font-size: 18px;
-  margin: 8px;
+  padding: 8px;
+  background-color: ${colors.White};
   ${tb`
-    margin: 4px;
+    padding: 4px;
   `}
 `;
 

--- a/src/components/templates/DetailPageComponent/index.tsx
+++ b/src/components/templates/DetailPageComponent/index.tsx
@@ -37,8 +37,15 @@ const InfoContainer = styled.div`
   margin-top: 22px;
 `;
 
-const DescriptionContainer = styled.section`
-  padding: ${spacingSizes.lg};
+const DescriptionSection = styled.section`
+  padding: 0 ${spacingSizes.lg};
+  margin-top: ${spacingSizes.lg};
+  ${tb`
+    padding: 0 ${spacingSizes.md};
+  `}
+  ${mb`
+    padding: 0 ${spacingSizes.sm};
+  `}
 `;
 
 const DescriptionHeader = styled.h2`

--- a/src/components/templates/DetailPageComponent/index.tsx
+++ b/src/components/templates/DetailPageComponent/index.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { ProductCard } from 'src/components/atoms/ProductCard';
 import { ProductPrice } from 'src/components/atoms/ProductPrice';
 import { ProductTag } from 'src/components/atoms/ProductTag';
 // eslint-disable-next-line import/no-cycle
@@ -57,10 +58,36 @@ const DescriptionContent = styled.p`
   `}
 `;
 
+const RelatedItemSection = styled.section`
+  padding: 0 ${spacingSizes.lg} ${spacingSizes.xl};
+  margin-top: ${spacingSizes.lg};
+  ${tb`
+    padding: 0 ${spacingSizes.md} ${spacingSizes.xl};
+  `}
+  ${mb`
+    padding: 0 ${spacingSizes.sm} ${spacingSizes.xl};
+  `}
+`;
+
+const RelatedItemTitle = styled.h2`
+  font-size: ${fontSizes.fontSize24};
+  font-style: ${fonts.NotoSansJP};
+  ${tb`
+    font-size: ${fontSizes.fontSize18};
+  `}
+`;
+
+const RelatedItemList = styled.div`
+  display: flex;
+  margin-top: ${spacingSizes.sm};
+  gap: ${spacingSizes.sm};
+`;
+
 export const DetailPageComponent: FC<{ props: DetailPageProps }> = ({
   props,
 }) => {
   const { id, name, thumbnail, price, tags, details } = props;
+  const relatedShopItems = props.related_shop_items;
   return (
     <Container>
       <TitleSection>
@@ -83,10 +110,23 @@ export const DetailPageComponent: FC<{ props: DetailPageProps }> = ({
           />
         </InfoContainer>
       </TitleSection>
-      <DescriptionContainer>
+      <DescriptionSection>
         <DescriptionHeader>{details[0].header}</DescriptionHeader>
         <DescriptionContent>{details[0].content}</DescriptionContent>
-      </DescriptionContainer>
+      </DescriptionSection>
+      <RelatedItemSection>
+        <RelatedItemTitle>関連商品</RelatedItemTitle>
+        <RelatedItemList>
+          {relatedShopItems.map((item) => (
+            <ProductCard
+              key={item.id}
+              name={item.name}
+              path={`/detail/${item.id}`}
+              thumbnail={item.thumbnail}
+            />
+          ))}
+        </RelatedItemList>
+      </RelatedItemSection>
     </Container>
   );
 };

--- a/src/components/templates/DetailPageComponent/index.tsx
+++ b/src/components/templates/DetailPageComponent/index.tsx
@@ -93,7 +93,7 @@ const RelatedItemList = styled.div`
 export const DetailPageComponent: FC<{ props: DetailPageProps }> = ({
   props,
 }) => {
-  const { id, name, thumbnail, price, tags, details } = props;
+  const { name, price, tags, details } = props;
   const relatedShopItems = props.related_shop_items;
   return (
     <Container>


### PR DESCRIPTION
# 概要
詳細画面の関連商品部分を実装しました。

# スクリーンショット
|storybook|figma|
|-|-|
|<img width="267" alt="image" src="https://github.com/arfes0e2b3c/yumeshop-frontend/assets/86275398/b7e185b0-cbd2-412d-b508-7b305e306a18">|<img width="707" alt="image" src="https://github.com/arfes0e2b3c/yumeshop-frontend/assets/86275398/6122ab5f-c2e9-411c-a320-fef7acca065e">|

# 動作確認
- `yarn dev`で開発用サーバーを起動
- 別ターミナルで`yarn run mock`でmockサーバーを起動
- [ここ](http://localhost:3000/detail/2ab06f5d-15f9-8c56-c685-e4fd103949fe)にアクセス
- デザインの齟齬が無いか、正常に動作するかを確認